### PR TITLE
Use sha256 instead of md5sum

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Use SHA256 instead of MD5 for verifying file integrity (:pr:`12`)
 * Add README file (:pr: `11`) and minor fixes
 * Use HTTPAdapter with retry strategy (:pr: `6`)
 * Updated registry to allow user defined registry.yaml (:pr: `8`)

--- a/packratt/conf/registry.yaml
+++ b/packratt/conf/registry.yaml
@@ -1,21 +1,21 @@
 '/test/ms/2020-06-04/google/smallest_ms.tar.gz':
   type: google
   file_id: 1wjZoh7OAIVEjYuTmg9dLAFiLoyehnIcL
-  hash: 4d548b22331fb3cd3256b1b4f37a41cf
+  hash: 9d6379b5ad01a1fe6ec218d4e58e4620fa80ff9820f4f54bf185d86496f3456c
   description: >
     Small testing Measurement Set, stored on Google Drive
 
 '/test/ms/2020-06-04/elwood/smallest_ms.tar.gz':
   type: url
   url: ftp://elwood.ru.ac.za/pub/sjperkins/data/test/smallest_ms.tar.gz
-  hash: 4d548b22331fb3cd3256b1b4f37a41cf
+  hash: 9d6379b5ad01a1fe6ec218d4e58e4620fa80ff9820f4f54bf185d86496f3456c
   description: >
     Small testing Measurement Set, stored on elwood's FTP server
 
 '/test/ms/2020-06-04/elwood/smallest_ms_truncated.tar.gz':
   type: url
   url: ftp://elwood.ru.ac.za/pub/sjperkins/data/test/smallest_ms_truncated.tar.gz
-  hash: 42e49e895d1f578c6a7e9b1684a61bef
+  hash: 0ddef067c03139ecff4d97724e4d5fac6ab56e0eff79a2f6a8cb985c4fe06601
   description: >
     Small testing Measurement Set, stored on elwood's FTP server,
     truncated at 100,000 bytes

--- a/packratt/interface.py
+++ b/packratt/interface.py
@@ -52,15 +52,15 @@ def get(key, destination, entry=None):
     if filename.exists():
         # TODO(sjperkins):
         # This is a massive assumption, what about partial downloads etc.
-        md5_hash = entry['hash']
+        sha256_hash = entry['hash']
     else:
         # Download to the destination
-        md5_hash = downloaders(entry['type'], key, entry)
+        sha256_hash = downloaders(entry['type'], key, entry)
 
-        if not md5_hash == entry['hash']:
-            raise ValueError("md5hash does not agree. %s vs %s"
-                             % (md5_hash, entry['hash']))
+        if not sha256_hash == entry['hash']:
+            raise ValueError("sha256hash does not agree. %s vs %s"
+                             % (sha256_hash, entry['hash']))
 
     shutil.unpack_archive(str(filename), destination)
 
-    return md5_hash
+    return sha256_hash

--- a/packratt/tests/test_get.py
+++ b/packratt/tests/test_get.py
@@ -11,7 +11,8 @@ import shutil
 def test_get_entry(google_key, tmp_path_factory):
     entry = {"type": 'google',
              "file_id": '1D62EwpZOL7I5MBVh5sskj7w9e-YaCSzX',
-             "hash": '3d6ab84b5ce54e8ac5b4e783458caf2afaaf5e8e3cca3ee082ae431498bd4b37',
+             "hash": ('3d6ab84b5ce54e8ac5b4e783458caf2a'
+                      'faaf5e8e3cca3ee082ae431498bd4b37'),
              "description": '1.5M water'}
     google_entry_dest = tmp_path_factory.mktemp("google")
     google_entry_sha256 = get(google_key, google_entry_dest, entry=entry)

--- a/packratt/tests/test_get.py
+++ b/packratt/tests/test_get.py
@@ -11,12 +11,12 @@ import shutil
 def test_get_entry(google_key, tmp_path_factory):
     entry = {"type": 'google',
              "file_id": '1D62EwpZOL7I5MBVh5sskj7w9e-YaCSzX',
-             "hash": '2acf32e159ed6076130d4c2680eca155',
+             "hash": '3d6ab84b5ce54e8ac5b4e783458caf2afaaf5e8e3cca3ee082ae431498bd4b37',
              "description": '1.5M water'}
     google_entry_dest = tmp_path_factory.mktemp("google")
-    google_entry_md5 = get(google_key, google_entry_dest, entry=entry)
+    google_entry_sha256 = get(google_key, google_entry_dest, entry=entry)
 
-    assert google_entry_md5 == entry['hash']
+    assert google_entry_sha256 == entry['hash']
 
 
 @pytest.mark.parametrize(
@@ -27,10 +27,10 @@ def test_get(google_key, elwood_key, test_cache, tmp_path_factory):
     google_dest = tmp_path_factory.mktemp("google")
     elwood_dest = tmp_path_factory.mktemp("elwood")
 
-    google_md5 = get(google_key, google_dest)
-    elwood_md5 = get(elwood_key, elwood_dest)
+    google_sha256 = get(google_key, google_dest)
+    elwood_sha256 = get(elwood_key, elwood_dest)
 
-    assert google_md5 == elwood_md5
+    assert google_sha256 == elwood_sha256
 
 
 @pytest.mark.parametrize(
@@ -41,8 +41,8 @@ def test_get(google_key, elwood_key, test_cache, tmp_path_factory):
     "google_key", ['/test/ms/2020-06-04/google/smallest_ms.tar.gz'])
 def test_get_partial(partial_key, google_key, elwood_key,
                      test_cache, registry, tmp_path_factory):
-    md5 = get(partial_key, tmp_path_factory.mktemp("ignore"))
-    assert md5 == registry[partial_key]['hash']
+    sha256 = get(partial_key, tmp_path_factory.mktemp("ignore"))
+    assert sha256 == registry[partial_key]['hash']
 
     partial_file = Path(test_cache.cache_key_dir(partial_key),
                         Path(partial_key).name)

--- a/packratt/tests/test_get.py
+++ b/packratt/tests/test_get.py
@@ -9,11 +9,12 @@ import shutil
 @pytest.mark.parametrize(
     "google_key", ['1.5M_water.tar.gz'])
 def test_get_entry(google_key, tmp_path_factory):
-    entry = {"type": 'google',
-             "file_id": '1D62EwpZOL7I5MBVh5sskj7w9e-YaCSzX',
-             "hash": ('3d6ab84b5ce54e8ac5b4e783458caf2a'
-                      'faaf5e8e3cca3ee082ae431498bd4b37'),
-             "description": '1.5M water'}
+    entry = {
+        "type": 'google',
+        "file_id": '1D62EwpZOL7I5MBVh5sskj7w9e-YaCSzX',
+        "hash": ('3d6ab84b5ce54e8ac5b4e783458caf2a'
+                 'faaf5e8e3cca3ee082ae431498bd4b37'),
+        "description": '1.5M water'}
     google_entry_dest = tmp_path_factory.mktemp("google")
     google_entry_sha256 = get(google_key, google_entry_dest, entry=entry)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,7 +52,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.4.5.1"
+version = "2020.6.20"
 
 [[package]]
 category = "main"
@@ -77,7 +77,7 @@ description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.2"
+version = "3.8.3"
 
 [package.dependencies]
 mccabe = ">=0.6.0,<0.7.0"
@@ -94,7 +94,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
+version = "2.10"
 
 [[package]]
 category = "main"
@@ -103,14 +103,14 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
+version = "1.7.0"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
 category = "dev"
@@ -170,7 +170,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.3.0"
+version = "8.4.0"
 
 [[package]]
 category = "main"
@@ -206,7 +206,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.1"
+version = "1.9.0"
 
 [[package]]
 category = "main"
@@ -310,7 +310,7 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.23.0"
+version = "2.24.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -366,7 +366,7 @@ description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.2.3"
+version = "0.2.5"
 
 [[package]]
 category = "dev"
@@ -414,8 +414,8 @@ attrs = [
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
 certifi = [
-    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
-    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -426,16 +426,16 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 flake8 = [
-    {file = "flake8-3.8.2-py2.py3-none-any.whl", hash = "sha256:ccaa799ef9893cebe69fdfefed76865aeaefbb94cb8545617b2298786a4de9a5"},
-    {file = "flake8-3.8.2.tar.gz", hash = "sha256:c69ac1668e434d37a2d2880b3ca9aafd54b3a10a3ac1ab101d22f29e29cf8634"},
+    {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
+    {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
 ]
 idna = [
-    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
-    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
-    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
+    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -473,8 +473,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
-    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
+    {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
+    {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -485,8 +485,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
-    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
+    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -529,9 +529,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 requests = [
-    {file = "requests-2.23.0-py2.7.egg", hash = "sha256:5d2d0ffbb515f39417009a46c14256291061ac01ba8f875b90cad137de83beb4"},
-    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
-    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -569,8 +568,8 @@ urllib3 = [
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.2.3-py2.py3-none-any.whl", hash = "sha256:980fbf4f3c196c0f329cdcd1e84c554d6a211f18e252e525a0cf4223154a41d6"},
-    {file = "wcwidth-0.2.3.tar.gz", hash = "sha256:edbc2b718b4db6cdf393eefe3a420183947d6aa312505ce6754516f458ff8830"},
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},


### PR DESCRIPTION
Based on https://askubuntu.com/a/173026

1. sha256 is a more secure hashing algorithm.
2. However, for the purposes of verifying file integrity, this doesn't matter.
3. However, the world seems to be moving towards SHA256 for hashing in any case.


